### PR TITLE
Replace strip_prefix with prefix in anaconda.yaml

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -3,7 +3,7 @@ upstream_sources:
   - github:
       identifier: stan-dev/cmdstan
       use_max_tag: true
-      strip_prefix: v
+      prefix: v
       exclude_regex: (?i)^(?=.*(?:(?<=\d)rc\d*|(?<=\d)dev\d+|(?:^|[-._])(?:alpha|beta|gamma|pre|preview)(?:\d+)?|[-._]rc\d+|(?:^|[-._])dev\d+|(?:\d+\.)+\d+[ab]\d*)).+$
       from_pattern: ^v?(\d+(?:\.\d+)*.*)$
       to_pattern: \1


### PR DESCRIPTION
## Summary
- Replace legacy `strip_prefix` with `prefix` in `anaconda.yaml`.

## Verification
- Config-only key rename; no recipe changes.

Made with [Cursor](https://cursor.com)